### PR TITLE
set right offset in resource.arsc

### DIFF
--- a/lib/ResourceFinder.js
+++ b/lib/ResourceFinder.js
@@ -99,6 +99,8 @@ ResourceFinder.prototype.processResourceTable = function(resourceBuffer) {
   if (size != bb.limit) {
     throw new Error("The buffer size not matches to the resource table size.");
   }
+  
+  bb.offset = headerSize;
 
   var realStringPoolCount = 0,
     realPackageCount = 0;


### PR DESCRIPTION
部分apk例如com.taobao.taobao_7.5.4.apk的resource.arsc头部不是默认大小